### PR TITLE
added a check for mac/Darwin to expand the home directory

### DIFF
--- a/nuke_util.py
+++ b/nuke_util.py
@@ -9,7 +9,7 @@ import colorsys
 import nuke  # type: ignore
 import nukescripts  # type: ignore
 
-if platform.system() == 'Linux':
+if platform.system() == 'Linux' or platform.system() == 'Darwin':
     user_path = os.path.expanduser('~')
 else:
     user_path = os.environ['USERPROFILE'].replace('\\', '/')


### PR DESCRIPTION
This check was failing on macOS and going straight to the Windows check which broke the tool.